### PR TITLE
Allow undefined `overrides` section in bower.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function gulpBowerNormalize(userOptions) {
     bowerJson = Path.join(process.cwd(), bowerJson);
 
     try {
-        overrides = require(bowerJson).overrides;
+        overrides = require(bowerJson).overrides || {};
     } catch(e) {
         throw new PluginError(PLUGIN_NAME, "No bower.json at " + bowerJson + " or overrides invalid!");
     }


### PR DESCRIPTION
The module errors when there is no `overrides` section defined in `bower.json`. Adding a blank `overrides` is a workaround. But I feel it should allow for no `overrides` section to be defined at all and still work.

```
TypeError: Cannot use 'in' operator to search for 'jquery' in undefined
    at DestroyableTransform._transform (C:\Users\Danny\Dev\nhrc-website\node_modules\gulp-bower-normalize\index.js:45:39)
```

``` json
{
  "name": "nhrc-website",
  "version": "0.0.0",
  "authors": [
    "Danny Fritz <dannyfritz@gmail.com>"
  ],
  "moduleType": [
    "node"
  ],
  "license": "MIT",
  "private": true,
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ],
  "dependencies": {
    "jquery": "~2.1.1",
    "font-awesome": "~4.2.0",
    "bootstrap": "~3.3.1"
  }
}
```
