### PR TITLE
add useExtnameFolder options

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function gulpBowerNormalize(userOptions) {
     // creating a stream through which each file will pass
     var stream = through.obj(function(file, enc, cb) {
         var components = getComponents(file),
-            type = components.ext,
+            type = options.useExtnameFolder ? components.ext : '',
             pkgOverrides = null,
             normalize = null;
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ function getComponents(file) {
     return {
         ext: Path.extname(relativePath).substr(1), // strip dot
         filename: Path.basename(relativePath),
-        packageName: pathParts[0]
+        packageName: pathParts.shift(),
+        path: pathParts.join(Path.sep)
     };
 }
 
@@ -41,6 +42,10 @@ function gulpBowerNormalize(userOptions) {
             type = options.useExtnameFolder ? components.ext : '',
             pkgOverrides = null,
             normalize = null;
+
+        if (!options.flat) {
+            type = Path.join(components.path, type);
+        }
 
         // Check if there are overrides
         if (components.packageName in overrides) {


### PR DESCRIPTION
well project !

but I want files don't dispatch with extname :)

and i think default value must be false;

```javascript
gulp.task("bower", ["src2dev", "bowerinstall"], function () {
    var mainBowerFiles = require("main-bower-files");
    var bowerNormalizer = require('gulp-bower-normalize');

    return gulp.src(mainBowerFiles({
            includeDev: true
        }), {
            base: "./bower_components"  //don't remove
        })
        .pipe(bowerNormalizer({
            useExtnameFolder: true   //default: false
            //bowerJson: "./bower.json"
        }))
        .pipe(gulp.dest(paths.dev + "/lib"));
});
```