### PR TITLE
Add checkPath option

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,14 @@ function gulpBowerNormalize(userOptions) {
                     filter.map(function(glob) {
                         // Potential bug here if multiple types match glob
                         // Last one in wins right now, maybe throw error?
-                        if (minimatch(components.filename, glob)) {
+                        var path = components.filename;
+
+                        // If checkPath is set to true, pass the relative path to the matching utility
+                        if (options.checkPath) {
+                            path = file.relative;
+                        }
+
+                        if (minimatch(path, glob)) {
                             type = key;
                         }
                     });

--- a/test/fixtures/bower.json
+++ b/test/fixtures/bower.json
@@ -30,6 +30,13 @@
     },
     "dependency6": {
       "main": "some/long/path/to/file.js"
+    },
+    "dependency7": {
+      "main": ["some.js", "some/other.js"],
+      "normalize": {
+        "js": "*.js",
+        "js/some": "**/some/*.js"
+      }
     }
   }
 }

--- a/test/path-parsing.spec.js
+++ b/test/path-parsing.spec.js
@@ -20,6 +20,14 @@ describe("gulp-bower-normalize", function() {
         });
     };
 
+    var assertPathChecked = function(fakeFile, expected) {
+        var myNormalizer = normalizer({checkPath: true, bowerJson: './test/fixtures/bower.json'});
+        myNormalizer.write(fakeFile);
+        myNormalizer.once("data", function(file) {
+            expect(file.path).to.equal(Path.normalize(expected));
+        });
+    };
+
     var getFakeFiles = function(packageName) {
         var bowerJson = require('./fixtures/bower.json');
         var depOverrides = bowerJson.overrides[packageName];
@@ -97,6 +105,12 @@ describe("gulp-bower-normalize", function() {
         assertNormalized(fakeFiles[0], '/path/dependency6/js/file.js');
     });
 
+    it("should normalize file paths from file names", function() {
+        var fakeFiles = getFakeFiles("dependency7");
+        assertNormalized(fakeFiles[0], '/path/dependency7/js/some.js');
+        assertNormalized(fakeFiles[1], '/path/dependency7/js/other.js');
+    });
+
     it("should implicitly set flattened path with override and no normalize", function() {
         var fakeFiles = getFakeFiles("dependency1");
         assertFlattened(fakeFiles[0], '/path/js/some.js');
@@ -128,5 +142,50 @@ describe("gulp-bower-normalize", function() {
     it("should flatten long file paths", function() {
         var fakeFiles = getFakeFiles("dependency6");
         assertFlattened(fakeFiles[0], '/path/js/file.js');
+    });
+
+    it("should flatten from file names", function() {
+        var fakeFiles = getFakeFiles("dependency7");
+        assertFlattened(fakeFiles[0], '/path/js/some.js');
+        assertFlattened(fakeFiles[1], '/path/js/other.js');
+    });
+
+    it("should implicitly fall back to extension", function() {
+        var fakeFiles = getFakeFiles("dependency1");
+        assertPathChecked(fakeFiles[0], '/path/dependency1/js/some.js');
+    });
+
+    it("should not match given pattern and fall back to extension", function() {
+        var fakeFiles = getFakeFiles("dependency2");
+        assertPathChecked(fakeFiles[0], '/path/dependency2/js/some.js');
+    });
+
+    it("should not match given patterns and fall back to extension", function() {
+        var fakeFiles = getFakeFiles("dependency3");
+        assertPathChecked(fakeFiles[0], '/path/dependency3/js/some.js');
+        assertPathChecked(fakeFiles[1], '/path/dependency3/css/some.css');
+    });
+
+    it("should not match given patterns and fall back to extension", function() {
+        var fakeFiles = getFakeFiles("dependency4");
+        assertPathChecked(fakeFiles[0], '/path/dependency4/js/some.js');
+        assertPathChecked(fakeFiles[1], '/path/dependency4/json/some.json');
+    });
+
+    it("should not match given patterns and fall back to extension", function() {
+        var fakeFiles = getFakeFiles("dependency5");
+        assertPathChecked(fakeFiles[0], '/path/dependency5/js/some.js');
+        assertPathChecked(fakeFiles[1], '/path/dependency5/json/some.json');
+    });
+
+    it("should not match given patterns and fall back to extension", function() {
+        var fakeFiles = getFakeFiles("dependency6");
+        assertPathChecked(fakeFiles[0], '/path/dependency6/js/file.js');
+    });
+
+    it("should match the pattern for the second file", function() {
+        var fakeFiles = getFakeFiles("dependency7");
+        assertPathChecked(fakeFiles[0], '/path/dependency7/js/some.js');
+        assertPathChecked(fakeFiles[1], '/path/dependency7/js/some/other.js');
     });
 });


### PR DESCRIPTION
As proposed in #6, the checkPath option (default: false) lets the user define more complex
patterns as the plugin checks the relative path instead of the filename