### PR TITLE
Multi project fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,19 @@ bower.json
 
 ###bowerNormalize(options)
 
+####options.basePath
+
+Type: `string`
+Default: `process.cwd()`
+
+Path to search for the bower.json file in.
+
 ####options.bowerJson
 
 Type: `string`
 Default: `./bower.json`
 
-Path to bower.json that overrides will come from. This should be relative to the gulpfile.js.
+Path to bower.json that overrides will come from. This should be relative to `options.BasePath`.
 
 ####options.flatten
 
@@ -100,6 +107,13 @@ Default: `false`
 Option to remove the component level folders. This would turn `/lib/jquery/js/jquery.js` into `/lib/js/jquery.js`.
 
 **Note:** If your components have files with the same name then only one of them will be included in the results.
+
+####options.typeTop
+
+Type: `boolean`
+Default: `false`
+
+Option to put the type folder on top of the hierarchy. This would turn `/lib/jquery/js/jquery.js` into `/lib/js/jquery/jquery.js`.
 
 ####options.checkPath
 

--- a/index.js
+++ b/index.js
@@ -24,10 +24,11 @@ function getComponents(file) {
 // plugin level function (dealing with files)
 function gulpBowerNormalize(userOptions) {
     var options = userOptions || {},
+        basePath = options.basePath || process.cwd(),
         bowerJson = options.bowerJson || "./bower.json",
         overrides = {};
 
-    bowerJson = Path.join(process.cwd(), bowerJson);
+    bowerJson = Path.join(basePath, bowerJson);
 
     try {
         overrides = require(bowerJson);

--- a/index.js
+++ b/index.js
@@ -120,6 +120,8 @@ function gulpBowerNormalize(userOptions) {
 
         if (options.flatten) {
             file.path = Path.join(file.base, type, components.filename);
+        } else if (options.typeTop) {
+            file.path = Path.join(file.base, type, components.packageName, components.filename);
         } else {
             file.path = Path.join(file.base, components.packageName, type, components.filename);
         }

--- a/index.js
+++ b/index.js
@@ -118,9 +118,9 @@ function gulpBowerNormalize(userOptions) {
         }
 
         if (options.flatten) {
-            file.path = Path.join(file.cwd, file.base, type, components.filename);
+            file.path = Path.join(file.base, type, components.filename);
         } else {
-            file.path = Path.join(file.cwd, file.base, components.packageName, type, components.filename);
+            file.path = Path.join(file.base, components.packageName, type, components.filename);
         }
 
         this.push(file);


### PR DESCRIPTION
Hey, I'm making a little thing that builds multiple projects with their own bower_components directories. To have this plugin work properly in this context, I've made some changes to it. This only brings it closer to the standard for gulp plugins (see changes).

Should not break any existing uses of the plugin, and doesn't break any tests. Sad to say I haven't the time to write any tests for the new options, but they currently work correctly in my build system, so should be fine.

Making this pull request to see if you're interested in the changes. Can add tests in a few months time.