### PR TITLE
added tests for `typeTop` options property

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/cthrax/gulp-bower-normalize",
   "dependencies": {
     "gulp-util": "^3.0.1",
-    "through2": "^0.6.3",
+    "through2": "^2.0.1",
     "minimatch": "^3.0.3",
     "path": "^0.4.9"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0.1",
     "through2": "^0.6.3",
-    "minimatch": "^1.0.0",
+    "minimatch": "^3.0.3",
     "path": "^0.4.9"
   },
   "devDependencies": {

--- a/test/path-typetop.spec.js
+++ b/test/path-typetop.spec.js
@@ -1,0 +1,74 @@
+var expect = require('chai').expect;
+var File = require('vinyl');
+var Path = require('path');
+var normalizer = require('../');
+var assertTypeTop = require('./utility').assertTypeTop;
+var getFakeFiles = require('./utility').getFakeFiles;
+describe('gulp-bower-normalize typeTop', function() {
+
+  it('should implicitly set normalized path without override section', function() {
+    var fakeFile = new File({
+      cwd: '/',
+      base: '/path',
+      path: '/path/to/a/file.ext'
+    });
+
+    var myNormalizer = normalizer({typeTop: true, bowerJson: './test/fixtures/bower-without-override.json'});
+    myNormalizer.write(fakeFile);
+    myNormalizer.once('data', function(file) {
+      console.log(file.path);
+      expect(file.path).to.equal(Path.normalize('/path/ext/to/file.ext'));
+    })
+  });
+
+  it('should implicitly set normalized path without overrides', function() {
+    var fakeFile = new File({
+      cwd: '/',
+      base: '/path',
+      path: '/path/to/a/file.ext'
+    });
+
+    assertTypeTop(fakeFile, '/path/ext/to/file.ext');
+  });
+
+  it('should implicitly set normalized path with overide and no normalize', function() {
+    var fakeFiles = getFakeFiles('dependency1');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency1/some.js');
+  });
+
+  it('should normalize based on explicit normalize overrides', function() {
+    var fakeFiles = getFakeFiles('dependency2');
+    assertTypeTop(fakeFiles[0], '/path/javascript/dependency2/some.js');
+  });
+
+  it('should normalize with mulitple normalization targets', function() {
+    var fakeFiles = getFakeFiles('dependency3');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency3/some.js');
+    assertTypeTop(fakeFiles[1], '/path/css/dependency3/some.css');
+  });
+
+  it('should normalize with multiple filter to one target', function() {
+    var fakeFiles = getFakeFiles('dependency4');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency4/some.js');
+    assertTypeTop(fakeFiles[1], '/path/js/dependency4/some.json');
+    fakeFiles = getFakeFiles('dependency8');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency8/some.js');
+  });
+
+  it('should normalize with a mix of implicit and explicit', function() {
+    var fakeFiles = getFakeFiles('dependency5');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency5/some.js');
+    assertTypeTop(fakeFiles[1], '/path/json/dependency5/some.json');
+  });
+
+  it('should normalize long file paths to a short path', function() {
+    var fakeFiles = getFakeFiles('dependency6');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency6/file.js');
+  });
+
+  it('should normalize file paths from file names', function() {
+    var fakeFiles = getFakeFiles('dependency7');
+    assertTypeTop(fakeFiles[0], '/path/js/dependency7/some.js');
+    assertTypeTop(fakeFiles[1], '/path/js/dependency7/other.js');
+  });
+});

--- a/test/utility.js
+++ b/test/utility.js
@@ -20,6 +20,13 @@ var assertNormalized = function(fakeFile, expected) {
     });
 };
 
+var assertTypeTop = function(fakeFile, expected) {
+  var myNormalizer = normalizer({typeTop: true, bowerJson: './test/fixtures/bower.json'});
+  myNormalizer.write(fakeFile);
+  myNormalizer.once('data', function(file) {
+    expect(file.path).to.equal(Path.normalize(expected));
+  });
+}
 var assertPathChecked = function(fakeFile, expected) {
     var myNormalizer = normalizer({checkPath: true, bowerJson: './test/fixtures/bower.json'});
     myNormalizer.write(fakeFile);
@@ -57,5 +64,6 @@ module.exports = {
     getFakeFiles: getFakeFiles,
     assertFlattened: assertFlattened,
     assertNormalized: assertNormalized,
+    assertTypeTop: assertTypeTop,
     assertPathChecked: assertPathChecked
 };


### PR DESCRIPTION
This deals with #12.

Also @cthrax, might you consider updating the rest of the project dependencies? I upgraded `minimatch` to alleviate some npm warnings during install. `through2` was just updated because the package was a few major versions out of date. Below is a list of updates that could be done:
```
 path          ^0.4.9  →  ^0.12.7
 chai         ^1.10.0  →   ^3.5.0
 gulp-eslint  ^0.11.1  →   ^3.0.1
 gulp-mocha    ^1.1.1  →   ^3.0.1
 vinyl         ^0.4.5  →   ^2.0.0
```
As reference I ran all the tests again with the updated packages and all passed.