### PR TITLE
update packages to use gulp 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 'strict';
 // through2 is a thin wrapper around node transform streams
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var minimatch = require('minimatch');
 var Path = require('path');
-var PluginError = gutil.PluginError;
 
 // consts
 var PLUGIN_NAME = 'gulp-bower-normalize';

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/cthrax/gulp-bower-normalize",
   "dependencies": {
-    "gulp-util": "^3.0.1",
-    "through2": "^2.0.1",
     "minimatch": "^3.0.3",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
I'm not sure how to test whether this deprecates certain versions of node.
But now this will run in the latest versions of node and use gulp 4.